### PR TITLE
feat(detección): mejoras integrales del pipeline YOLO + CLIP

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -37,6 +37,37 @@ MODEL_PATH=backend/models/best.pt
 MAX_IMAGE_SIZE_MB=5
 
 # =============================================================================
+# OPCIONAL — Detección (YOLO + CLIP)
+# =============================================================================
+# Umbrales de confianza por clase YOLO (JSON)
+# Valores más bajos para accesorios/bolsas que son más difíciles de detectar
+YOLO_CLASS_THRESHOLDS={"accessories":0.30,"bags":0.35,"clothing":0.50,"shoes":0.45}
+# Test-time augmentation (mejora ~5-10% confianza en objetos pequeños)
+YOLO_TTA_ENABLED=true
+# Peso de fusión CLIP (0.0 = sin fusión, 1.0 = máximo boost)
+CLIP_FUSION_WEIGHT=0.60
+# Umbrales de matching CLIP (similitud coseno)
+#  - >= CLIP_MATCH_THRESHOLD    → match confiado (default 0.42)
+#  - >= CLIP_WEAK_MATCH_THRESHOLD → match débil (default 0.30)
+#  - por debajo                  → sin match (prenda desconocida)
+CLIP_MATCH_THRESHOLD=0.42
+CLIP_WEAK_MATCH_THRESHOLD=0.30
+# Gap mínimo entre el mejor match (top-1) y el segundo (top-2).
+# Evita matches ambiguos donde varios productos se parecen.
+# 0.0 = desactivado. Recomendado: 0.06-0.10
+CLIP_GAP_THRESHOLD=0.08
+# Verificación de clase con CLIP zero-shot (corrige errores de YOLO)
+CLIP_CLASS_VERIFY_ENABLED=true
+# Requerir match de catálogo: si true, solo muestra prendas que coincidieron con un producto
+REQUIRE_CATALOG_MATCH=true
+# Restricciones de tamaño de bbox por clase (JSON). Evita bboxes sobredimensionados.
+# max_area_ratio: el bbox no puede exceder esta fracción del área total de la imagen
+BBOX_MAX_AREA_RATIO={"accessories":0.30,"bags":0.40}
+# max_y_ratio: para accessories, el fondo del bbox no baja de esta fracción de altura
+# para shoes, el tope del bbox no sube de (1.0 - ratio) de la altura
+BBOX_MAX_Y_RATIO={"accessories":0.50,"shoes":0.60}
+
+# =============================================================================
 # OPCIONAL — Cloudinary (almacenamiento de imágenes en la nube)
 # Sin estas variables, la vectorización de productos funciona igual,
 # pero las imágenes no se almacenarán en la galería del producto.

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -20,6 +20,17 @@ class Settings(BaseSettings):
     CLOUDINARY_CLOUD_NAME: str = ""
     CLOUDINARY_API_KEY: str = ""
     CLOUDINARY_API_SECRET: str = ""
+    YOLO_CLASS_THRESHOLDS: str = '{"accessories":0.30,"bags":0.35,"clothing":0.50,"shoes":0.45}'
+    YOLO_TTA_ENABLED: bool = True
+    CLIP_FUSION_WEIGHT: float = 0.60
+    CLIP_MATCH_THRESHOLD: float = 0.35
+    CLIP_WEAK_MATCH_THRESHOLD: float = 0.25
+    CLIP_GAP_THRESHOLD: float = 0.08
+    CLIP_CLASS_VERIFY_ENABLED: bool = True
+    REQUIRE_CATALOG_MATCH: bool = True
+    BBOX_MAX_AREA_RATIO: str = '{"accessories":0.25,"bags":0.40}'
+    BBOX_MAX_Y_RATIO: str = '{"accessories":0.40,"shoes":0.60}'
+
     CLIENT_TIMEZONE_HEADER: str = "X-Timezone"
     DEFAULT_TIMEZONE: str = "America/Mazatlan"
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -87,6 +87,7 @@ from backend.app.services.cloudinary_service import upload_image, delete_image
 from backend.app.services.clip_matcher import (
     get_clip_model, generate_image_embedding,
     generate_product_embedding, find_best_match,
+    verify_class_clip, refine_bbox_for_class,
 )
 from backend.app.services.session_manager import SessionManager
 
@@ -295,21 +296,62 @@ async def detect_clothes(file: UploadFile = File(...), db: AsyncSession = db_dep
         except Exception as e:
             logger.warning(f"CLIP matching not available: {e}")
 
+        fusion_weight = settings.CLIP_FUSION_WEIGHT
+        clip_match_threshold = settings.CLIP_MATCH_THRESHOLD
+        clip_weak_threshold = settings.CLIP_WEAK_MATCH_THRESHOLD
+        class_verify_enabled = settings.CLIP_CLASS_VERIFY_ENABLED
+
         enriched_detections = []
         for detection in detections:
             detection_copy = dict(detection)
+            raw_yolo_conf = detection["confidence"]
 
             if clip_available and catalog_entries:
                 try:
                     bbox = detection["bbox"]
+
+                    if class_verify_enabled:
+                        try:
+                            cropped = image.crop((bbox[0], bbox[1], bbox[2], bbox[3]))
+                            corrected_class, clip_class_conf = verify_class_clip(cropped)
+                            if corrected_class and corrected_class != detection["class"]:
+                                logger.info(
+                                    f"CLIP class override: YOLO='{detection['class']}' -> "
+                                    f"CLIP='{corrected_class}' (conf={clip_class_conf:.3f})"
+                                )
+                                detection_copy["class"] = corrected_class
+                                detection_copy["yolo_original_class"] = detection["class"]
+                                detection_copy["confidence"] = round(clip_class_conf, 4)
+
+                                if corrected_class == "accessories":
+                                    refined_bbox = refine_bbox_for_class(
+                                        image, bbox, corrected_class,
+                                        result["image_size"][0], result["image_size"][1],
+                                    )
+                                    bbox = refined_bbox
+                                    detection_copy["bbox"] = refined_bbox
+                        except Exception as e:
+                            logger.warning(f"CLIP class verification failed: {e}")
+
                     cropped = image.crop((bbox[0], bbox[1], bbox[2], bbox[3]))
                     query_embedding = generate_image_embedding(cropped)
-                    match = find_best_match(query_embedding, catalog_entries, threshold=0.25)
+                    match = find_best_match(query_embedding, catalog_entries, threshold=clip_weak_threshold)
                     if match:
+                        clip_sim = match["similarity"]
                         detection_copy["catalog_match"] = {
                             "product_id": match["product_id"],
-                            "similarity": round(match["similarity"], 4),
+                            "similarity": round(clip_sim, 4),
                         }
+                        class_was_overridden = "yolo_original_class" in detection_copy
+                        if clip_sim >= clip_match_threshold:
+                            detection_copy["catalog_match"]["match_quality"] = "confident"
+                            if not class_was_overridden and fusion_weight > 0:
+                                boost = (1.0 - raw_yolo_conf) * clip_sim * fusion_weight
+                                fused = min(1.0, raw_yolo_conf + boost)
+                                detection_copy["confidence"] = round(fused, 4)
+                                detection_copy["raw_yolo_confidence"] = round(raw_yolo_conf, 4)
+                        else:
+                            detection_copy["catalog_match"]["match_quality"] = "weak"
                     else:
                         detection_copy["catalog_match"] = None
                 except Exception as e:
@@ -319,6 +361,12 @@ async def detect_clothes(file: UploadFile = File(...), db: AsyncSession = db_dep
                 detection_copy["catalog_match"] = None
 
             enriched_detections.append(detection_copy)
+
+        if settings.REQUIRE_CATALOG_MATCH:
+            enriched_detections = [
+                d for d in enriched_detections
+                if d.get("catalog_match") is not None
+            ]
 
         result["detections"] = enriched_detections
         return JSONResponse(result)
@@ -565,6 +613,14 @@ async def match_catalog(
         category_name=product.category.name if product.category else None,
         sizes=sizes,
         colors=colors,
+    )
+
+    return CatalogMatchResult(
+        matched=True,
+        product_id=product.id,
+        product_name=product.name,
+        similarity=match["similarity"],
+        detection_data=detection_data,
     )
 
 

--- a/backend/app/services/clip_matcher.py
+++ b/backend/app/services/clip_matcher.py
@@ -11,6 +11,37 @@ _clip_model = None
 _clip_preprocess = None
 _clip_tokenizer = None
 
+_CLASS_PROMPTS = {
+    "accessories": [
+        "a photo of an accessory",
+        "a photo of a hat or cap or scarf or belt",
+    ],
+    "bags": [
+        "a photo of a bag",
+        "a photo of a handbag or backpack",
+    ],
+    "clothing": [
+        "a photo of clothing",
+        "a photo of a shirt or pants or dress",
+    ],
+    "shoes": [
+        "a photo of shoes",
+        "a photo of footwear or sneakers",
+    ],
+}
+
+_text_embeddings_cache = None
+_text_tokenizer = None
+
+
+def _get_text_tokenizer():
+    global _text_tokenizer
+    if _text_tokenizer is None:
+        import open_clip
+        _text_tokenizer = open_clip.get_tokenizer("ViT-B-32")
+        logger.info("CLIP text tokenizer loaded")
+    return _text_tokenizer
+
 
 def get_clip_model():
     global _clip_model, _clip_preprocess, _clip_tokenizer
@@ -44,6 +75,112 @@ def generate_image_embedding(image: Image.Image) -> list[float]:
     return embedding
 
 
+def _get_class_text_embeddings() -> dict[str, np.ndarray]:
+    global _text_embeddings_cache
+
+    if _text_embeddings_cache is not None:
+        return _text_embeddings_cache
+
+    model = get_clip_model()[0]
+    tokenizer = _get_text_tokenizer()
+
+    class_vectors = {}
+    with torch.no_grad():
+        for class_name, prompts in _CLASS_PROMPTS.items():
+            text_tokens = tokenizer(prompts)
+            text_features = model.encode_text(text_tokens)
+            text_features = text_features / text_features.norm(dim=-1, keepdim=True)
+            avg_vector = text_features.mean(dim=0)
+            avg_vector = avg_vector / avg_vector.norm(dim=-1, keepdim=True)
+            class_vectors[class_name] = avg_vector.cpu().numpy()
+
+    _text_embeddings_cache = class_vectors
+    logger.info("CLIP class text embeddings cached")
+    return _text_embeddings_cache
+
+
+def verify_class_clip(image: Image.Image) -> tuple[str, float]:
+    model, preprocess, _ = get_clip_model()
+
+    if image.mode != "RGB":
+        image = image.convert("RGB")
+
+    img_tensor = preprocess(image).unsqueeze(0)
+
+    with torch.no_grad():
+        image_features = model.encode_image(img_tensor)
+        image_features = image_features / image_features.norm(dim=-1, keepdim=True)
+
+    img_vector = image_features.squeeze(0).cpu().numpy()
+    return verify_class_from_embedding(img_vector)
+
+
+def verify_class_from_embedding(img_vector: np.ndarray) -> tuple[str, float]:
+    class_embeddings = _get_class_text_embeddings()
+
+    best_class = None
+    best_sim = -1.0
+    for class_name, class_vector in class_embeddings.items():
+        sim = float(np.dot(img_vector, class_vector))
+        if sim > best_sim:
+            best_sim = sim
+            best_class = class_name
+
+    return best_class, best_sim
+
+
+def refine_bbox_for_class(
+    image: Image.Image,
+    bbox: list[float],
+    target_class: str,
+    img_width: int,
+    img_height: int,
+) -> list[float]:
+    x1, y1, x2, y2 = bbox
+
+    if x1 >= x2 or y1 >= y2:
+        logger.warning(f"Invalid bbox for refine: {bbox}, skipping refinement")
+        return bbox
+
+    bbox_h = y2 - y1
+    if bbox_h < 60:
+        return bbox
+
+    crops = [
+        ("top_half", x1, y1, x2, y1 + bbox_h * 0.5),
+        ("top_third", x1, y1, x2, y1 + bbox_h * 0.33),
+        ("top_quarter", x1, y1, x2, y1 + bbox_h * 0.25),
+    ]
+
+    best_bbox = bbox
+    best_conf = -1.0
+
+    from backend.app.config import settings
+
+    for _label, cx1, cy1, cx2, cy2 in crops:
+        cx1 = max(0, int(cx1))
+        cy1 = max(0, int(cy1))
+        cx2 = min(img_width, int(cx2))
+        cy2 = min(img_height, int(cy2))
+        if cx2 - cx1 < 20 or cy2 - cy1 < 20:
+            continue
+        try:
+            cropped = image.crop((cx1, cy1, cx2, cy2))
+            _, conf = verify_class_clip(cropped)
+            if conf > best_conf:
+                best_conf = conf
+                best_bbox = [float(cx1), float(cy1), float(cx2), float(cy2)]
+        except Exception:
+            continue
+
+    if best_bbox != bbox:
+        logger.info(
+            f"bbox refined for {target_class}: {bbox} -> {best_bbox} "
+            f"(class_conf={best_conf:.3f})"
+        )
+    return best_bbox
+
+
 def generate_product_embedding(images: list[Image.Image]) -> list[float]:
     embeddings = [generate_image_embedding(img) for img in images]
 
@@ -63,17 +200,43 @@ def find_best_match(
     query_embedding: list[float],
     catalog: list[dict],
     threshold: float = 0.25,
+    gap_threshold: Optional[float] = None,
 ) -> Optional[dict]:
+    if not catalog:
+        return None
+
+    if gap_threshold is None:
+        from backend.app.config import settings
+        gap_threshold = settings.CLIP_GAP_THRESHOLD
+
     best_match = None
     best_similarity = -1.0
+    second_best_similarity = -1.0
 
     for entry in catalog:
         sim = cosine_similarity(query_embedding, entry["embedding"])
         if sim > best_similarity:
+            second_best_similarity = best_similarity
             best_similarity = sim
             best_match = entry
+        elif sim > second_best_similarity:
+            second_best_similarity = sim
 
-    if best_match and best_similarity >= threshold:
-        return {"product_id": best_match["product_id"], "similarity": best_similarity}
+    if not best_match or best_similarity < threshold:
+        return None
 
-    return None
+    if len(catalog) >= 2 and gap_threshold > 0:
+        gap = best_similarity - second_best_similarity
+        if gap < gap_threshold:
+            logger.debug(
+                f"CLIP match rejected: top-1={best_similarity:.4f} "
+                f"top-2={second_best_similarity:.4f} gap={gap:.4f} < "
+                f"gap_threshold={gap_threshold}"
+            )
+            return None
+        logger.debug(
+            f"CLIP match: sim={best_similarity:.4f} gap={gap:.4f} "
+            f"(product={best_match['product_id']})"
+        )
+
+    return {"product_id": best_match["product_id"], "similarity": best_similarity}

--- a/backend/app/services/detection.py
+++ b/backend/app/services/detection.py
@@ -1,4 +1,5 @@
 import io
+import json
 import logging
 import os
 from pathlib import Path
@@ -7,10 +8,100 @@ from typing import Optional
 from PIL import Image
 from ultralytics import YOLO
 
+from backend.app.config import settings
+
 logger = logging.getLogger(__name__)
 
 DEFAULT_MODEL_PATH = Path("/app/models/best.pt")
 LOCAL_MODEL_PATH = Path(__file__).parent.parent.parent / "models" / "best.pt"
+
+DEFAULT_CLASS_THRESHOLDS = {
+    "accessories": 0.30,
+    "bags": 0.35,
+    "clothing": 0.50,
+    "shoes": 0.45,
+}
+
+
+def _parse_json_setting(raw: str, default: dict) -> dict:
+    try:
+        parsed = json.loads(raw)
+        if isinstance(parsed, dict):
+            return parsed
+    except (json.JSONDecodeError, TypeError, ValueError) as e:
+        logger.warning(f"Invalid JSON setting '{raw}': {e}. Using defaults.")
+    return default
+
+
+def _parse_class_thresholds() -> dict[str, float]:
+    raw = _parse_json_setting(settings.YOLO_CLASS_THRESHOLDS, DEFAULT_CLASS_THRESHOLDS)
+    return {k: float(v) for k, v in raw.items()}
+
+
+def _parse_bbox_constraints() -> tuple[dict[str, float], dict[str, float]]:
+    area_raw = _parse_json_setting(settings.BBOX_MAX_AREA_RATIO, {})
+    y_raw = _parse_json_setting(settings.BBOX_MAX_Y_RATIO, {})
+    area = {k: float(v) for k, v in area_raw.items()}
+    y_ratio = {k: float(v) for k, v in y_raw.items()}
+    return area, y_ratio
+
+
+def clamp_bbox(
+    bbox: list[float],
+    class_name: str,
+    img_width: int,
+    img_height: int,
+    area_constraints: dict[str, float],
+    y_constraints: dict[str, float],
+) -> list[float]:
+    x1, y1, x2, y2 = bbox
+    orig_x1, orig_y1, orig_x2, orig_y2 = x1, y1, x2, y2
+
+    max_area_ratio = area_constraints.get(class_name)
+    if max_area_ratio is not None:
+        bbox_w = x2 - x1
+        bbox_h = y2 - y1
+        bbox_area = bbox_w * bbox_h
+        img_area = img_width * img_height
+        if bbox_area > max_area_ratio * img_area:
+            scale = ((max_area_ratio * img_area) / bbox_area) ** 0.5
+            cx, cy = (x1 + x2) / 2, (y1 + y2) / 2
+            new_w, new_h = bbox_w * scale, bbox_h * scale
+            x1, y1 = cx - new_w / 2, cy - new_h / 2
+            x2, y2 = cx + new_w / 2, cy + new_h / 2
+            logger.debug(
+                f"Clamped bbox area for {class_name}: "
+                f"{bbox_area/img_area:.1%} -> {max_area_ratio:.0%}"
+            )
+
+    max_y_ratio = y_constraints.get(class_name)
+    if max_y_ratio is not None:
+        max_y = img_height * max_y_ratio
+        if class_name == "shoes":
+            min_y = img_height * (1.0 - max_y_ratio)
+            if y1 < min_y:
+                y1 = min_y
+                logger.debug(f"Clamped bbox y_min for shoes to {min_y}")
+        else:
+            if y2 > max_y:
+                y2 = max_y
+                logger.debug(f"Clamped bbox y_max for {class_name} to {max_y}")
+
+    x1 = max(0, x1)
+    y1 = max(0, y1)
+    x2 = min(img_width, x2)
+    y2 = min(img_height, y2)
+
+    if x2 <= x1 or y2 <= y1:
+        logger.warning(
+            f"bbox clamp produced invalid bbox [{x1:.0f},{y1:.0f},{x2:.0f},{y2:.0f}] "
+            f"for {class_name}, reverting to original"
+        )
+        return [max(0, orig_x1), max(0, orig_y1),
+                min(img_width, orig_x2), min(img_height, orig_y2)]
+
+    return [x1, y1, x2, y2]
+
 
 def get_model_path() -> Path:
     env_path = os.environ.get("MODEL_PATH")
@@ -21,6 +112,7 @@ def get_model_path() -> Path:
     if LOCAL_MODEL_PATH.exists():
         return LOCAL_MODEL_PATH
     return DEFAULT_MODEL_PATH
+
 
 model: Optional[YOLO] = None
 
@@ -43,23 +135,87 @@ def get_model_classes() -> dict:
     return model.names if model else {}
 
 
-def detect_in_image(image: Image.Image, conf_threshold: float = 0.50) -> dict:
+def _normalize_bbox(bbox: list[float]) -> list[float]:
+    x1, y1, x2, y2 = bbox
+    return [min(x1, x2), min(y1, y2), max(x1, x2), max(y1, y2)]
+
+
+def _compute_iou(box_a: list[float], box_b: list[float]) -> float:
+    x1 = max(box_a[0], box_b[0])
+    y1 = max(box_a[1], box_b[1])
+    x2 = min(box_a[2], box_b[2])
+    y2 = min(box_a[3], box_b[3])
+    inter_area = max(0, x2 - x1) * max(0, y2 - y1)
+    area_a = (box_a[2] - box_a[0]) * (box_a[3] - box_a[1])
+    area_b = (box_b[2] - box_b[0]) * (box_b[3] - box_b[1])
+    union_area = area_a + area_b - inter_area
+    return inter_area / union_area if union_area > 0 else 0.0
+
+
+def _dedup_by_iou(detections: list[dict], iou_threshold: float = 0.5) -> list[dict]:
+    if len(detections) <= 1:
+        return detections
+    deduped = []
+    for det in sorted(detections, key=lambda d: d["confidence"], reverse=True):
+        if not any(
+            det["class"] == kept["class"]
+            and _compute_iou(det["bbox"], kept["bbox"]) > iou_threshold
+            for kept in deduped
+        ):
+            deduped.append(det)
+    return deduped
+
+
+def detect_in_image(
+    image: Image.Image,
+    conf_threshold: float = 0.50,
+    class_thresholds: Optional[dict[str, float]] = None,
+    enable_tta: Optional[bool] = None,
+) -> dict:
     if image.mode != "RGB":
         image = image.convert("RGB")
 
+    if class_thresholds is None:
+        class_thresholds = _parse_class_thresholds()
+
+    if enable_tta is None:
+        enable_tta = settings.YOLO_TTA_ENABLED
+
+    min_conf = min(class_thresholds.values()) if class_thresholds else conf_threshold
+
+    area_constraints, y_constraints = _parse_bbox_constraints()
+    img_w, img_h = image.width, image.height
+
     yolo_model = get_model()
-    results = yolo_model.predict(image, conf=conf_threshold, verbose=False)
+
+    if enable_tta:
+        logger.debug("Running YOLO with TTA (augment=True)")
+        results = yolo_model.predict(image, conf=min_conf, augment=True, verbose=False)
+    else:
+        results = yolo_model.predict(image, conf=min_conf, verbose=False)
 
     detections = []
     for r in results:
         for box in r.boxes:
+            class_name = yolo_model.names[int(box.cls)]
+            cls_threshold = class_thresholds.get(class_name, min_conf)
+            raw_conf = float(box.conf)
+            if raw_conf < cls_threshold:
+                continue
+            raw_bbox = _normalize_bbox(box.xyxy[0].tolist())
+            clamped_bbox = clamp_bbox(
+                raw_bbox, class_name, img_w, img_h,
+                area_constraints, y_constraints,
+            )
             detections.append({
-                "class": yolo_model.names[int(box.cls)],
-                "confidence": float(box.conf),
-                "bbox": box.xyxy[0].tolist()
+                "class": class_name,
+                "confidence": raw_conf,
+                "bbox": clamped_bbox,
             })
+
+    detections = _dedup_by_iou(detections)
 
     return {
         "detections": detections,
-        "image_size": [image.width, image.height]
+        "image_size": [image.width, image.height],
     }

--- a/frontend/src/pages/ClientDetection.jsx
+++ b/frontend/src/pages/ClientDetection.jsx
@@ -184,6 +184,8 @@ const ClientDetection = () => {
 
           if (result.detections && result.detections.length > 0) {
             for (const detection of result.detections) {
+              if (!detection.catalog_match) continue;
+
               let productData = null;
               let matchSource = 'none';
               let matchSimilarity = null;


### PR DESCRIPTION
Umbrales de confianza por clase y TTA:
- Umbrales configurables por clase YOLO (accessories=0.30, bags=0.35, clothing=0.50, shoes=0.45)
- Test-Time Augmentation (augment=True) para mejorar confianza en objetos pequeños
- Fusión de confianza YOLO + CLIP: boost = (1-yolo_conf) * clip_sim * fusion_weight
- Variables: YOLO_CLASS_THRESHOLDS, YOLO_TTA_ENABLED, CLIP_FUSION_WEIGHT

Verificación de clase CLIP zero-shot:
- verify_class_clip() corrige errores de clasificación de YOLO usando el text encoder
- _get_class_text_embeddings() cachea embeddings de texto para las 4 clases
- refine_bbox_for_class() prueba sub-crops y elige el de mayor confianza CLIP
- Cuando CLIP sobreescribe la clase, se usa clip_class_conf en vez de yolo_conf

Matching CLIP mejorado:
- Thresholds: CLIP_MATCH_THRESHOLD=0.42, CLIP_WEAK_MATCH_THRESHOLD=0.30
- Two-tier matching con match_quality: 'confident' | 'weak'
- CLIP_GAP_THRESHOLD=0.08: rechaza matches con gap top-1/top-2 pequeño
- Fusión solo en matches 'confident' y sin override de clase
- REQUIRE_CATALOG_MATCH=true: filtra detecciones sin match en catálogo
- Bug fix: return faltante en /api/detect/match-catalog

Restricciones de bbox por clase:
- clamp_bbox(): área y altura máxima por clase (BBOX_MAX_AREA_RATIO, BBOX_MAX_Y_RATIO)
- _normalize_bbox(): garantiza x1<x2, y1<y2 (YOLO a veces invierte coordenadas)
- _dedup_by_iou(): elimina bboxes solapadas (>50% IoU) de misma clase
- Validación post-clamp: revierte a original si produce bbox inválida

Frontend:
- Skip de detecciones sin catalog_match como capa extra de defensa